### PR TITLE
include useQRCode logic path to return invoice string

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
+    "watch": "tsup src/index.ts --format cjs,esm --dts --watch",
     "lint": "tsc",
     "outdated": "bunx npm-check-updates -ui -p bun"
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,7 +46,10 @@ export type ZapParams = {
   secretKey?: Uint8Array;
   initialDelay?: number;
   retryInterval?: number;
-  onPaymentSuccess?: (sendPaymentResponse: SendPaymentResponse) => void;
+  useQRCode?: boolean;
+  onPaymentSuccess?: (
+    sendPaymentResponse: SendPaymentResponse | string
+  ) => void;
   onPaymentFailure?: () => void;
   onZapReceipts?: (events: Event[]) => void;
   onNoZapReceipts?: () => void;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -42,14 +42,14 @@ export function tag(key: string, event: Event | undefined) {
 export function allTags(key: string, event: Event): string[] {
   return event.tags
     .filter(
-      (innerArray) => innerArray[0] === key && innerArray[1] !== undefined,
+      (innerArray) => innerArray[0] === key && innerArray[1] !== undefined
     )
     .map((innerArray) => innerArray[1]!);
 }
 
 export const createNaddr = (
   event: Event | undefined,
-  relays: RelayUrl[] | undefined = undefined,
+  relays: RelayUrl[] | undefined = undefined
 ) => {
   const identifier = tag("d", event);
   if (!identifier) {
@@ -81,7 +81,7 @@ function generateUniqueHash(data: string, length: number) {
 export async function finishEvent(
   t: EventTemplate,
   secretKey?: Uint8Array,
-  onErr?: (err: Error) => void,
+  onErr?: (err: Error) => void
 ) {
   let event = t as Event;
   if (secretKey) {
@@ -92,6 +92,7 @@ export async function finishEvent(
         event.pubkey = await nostr.getPublicKey();
         event.id = getEventHash(event);
         event = (await nostr.signEvent(event)) as Event;
+        console.log("signed event", event);
         return event;
       } else {
         console.error("nostr not defined");
@@ -119,7 +120,7 @@ export function createIdentifier(title: string, pubkey: string): string {
 
 export function identityTag(
   platform: string,
-  tags: (string | undefined)[][],
+  tags: (string | undefined)[][]
 ): (string | undefined)[] | undefined {
   return tags.find((tag) => tag[0] === "i" && tag[1]?.startsWith(platform));
 }


### PR DESCRIPTION
This PR adds the useQRCode param to the `zap` method that is returned from the hook. This allows the consuming component to get the lightning invoice string and pass it on to the signing application (via the invoke method)